### PR TITLE
Add monitoring and refactor handle()

### DIFF
--- a/tests/test_pigeon.py
+++ b/tests/test_pigeon.py
@@ -46,7 +46,7 @@ def test_non_put_event(client, rabbitmq_helper):
     assert item is None
 
 
-def test_defer(client, rabbitmq_helper):
+def test_defer(client, rabbitmq_helper, capsys):
     crash_id = 'de1bb258-cbbf-4589-a673-34f801160918'
     #                                        ^ defer
     events = client.build_crash_save_events(client.crash_id_to_path(crash_id))
@@ -54,6 +54,22 @@ def test_defer(client, rabbitmq_helper):
 
     item = rabbitmq_helper.next_item()
     assert item is None
+
+    stdout, stderr = capsys.readouterr()
+    assert '|1|count|antenna.pigeon.defer|' in stdout
+
+
+def test_accept(client, rabbitmq_helper, capsys):
+    crash_id = 'de1bb258-cbbf-4589-a673-34f800160918'
+    #                                        ^ accept
+    events = client.build_crash_save_events(client.crash_id_to_path(crash_id))
+    assert client.run(events) is None
+
+    item = rabbitmq_helper.next_item()
+    assert item == crash_id
+
+    stdout, stderr = capsys.readouterr()
+    assert '|1|count|antenna.pigeon.accept|' in stdout
 
 
 @pytest.mark.parametrize('data, expected', [


### PR DESCRIPTION
This turns handle inside-out so that it first checks to see if it has any
crash_ids that need to be accepted and if it does, then creates a RabbitMQ
connection. Otherwise it doesn't.

This adds monitoring for accept, defer and pika_error counts using the format
that Datadog is expecting.

This adds a test for the accept case, too.